### PR TITLE
Fix user retrieval in action hook

### DIFF
--- a/vikrentcar.php
+++ b/vikrentcar.php
@@ -256,7 +256,7 @@ add_shortcode('vikrentcar', function($atts, $content = null)
 add_action('vikrentcar_before_dispatch', function()
 {
 	$app 	= JFactory::getApplication();
-	$user 	= Jfactory::getUser();
+	$user 	= JFactory::getUser();
 
 	// initialize timezone handler
 	JDate::getDefaultTimezone();


### PR DESCRIPTION
## Summary
- correct case for user retrieval function in `vikrentcar_before_dispatch` action

## Testing
- `php -l vikrentcar.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420087de4c832ab5d14641fcb9a461