### PR TITLE
Fix last_keyword property name in VRCCalendarIcal

### DIFF
--- a/admin/helpers/src/calendar/ical.php
+++ b/admin/helpers/src/calendar/ical.php
@@ -21,7 +21,7 @@ class VRCCalendarIcal
 	public $todo_count = 0;
 	public $event_count = 0;
 	public $cal = [];
-	private $_lastKeyWord;
+	private $last_keyword;
 
 	private $site_tz_id;
 


### PR DESCRIPTION
## Summary
- correct naming of property `$last_keyword`
- use `$this->last_keyword` consistently

## Testing
- `php -l admin/helpers/src/calendar/ical.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842009338e8832ab1d69089d9c1b010