### PR TITLE
Fix debug check for non-WordPress contexts

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -25,6 +25,7 @@ require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'defines.php';
 $request_debug  = (isset($_GET['debug']) && $_GET['debug'] === 'on') ||
                   (isset($_GET['error_reporting']) && (int) $_GET['error_reporting'] === -1);
 $authorized_user = function_exists('current_user_can') &&
+                  function_exists('is_user_logged_in') &&
                   is_user_logged_in() && current_user_can('manage_options');
 
 if (VIKRENTCAR_DEBUG || ($request_debug && $authorized_user))


### PR DESCRIPTION
## Summary
- avoid fatal error in `autoload.php` when `is_user_logged_in()` is unavailable

## Testing
- `grep -n authorized_user autoload.php`

------
https://chatgpt.com/codex/tasks/task_e_68420a8bfba4832abf59823ca67c8204