### PR TITLE
Add fallback capability check in authorise()

### DIFF
--- a/libraries/adapter/changelog.md
+++ b/libraries/adapter/changelog.md
@@ -7,6 +7,7 @@
 ##### BUG FIXES
 
 * The site widgets now always use an incremental identifier, since WordPress is no longer able to provide a unique number when publishing them as Gutenberg blocks.
+* Added fallback capability check in `JUser::authorise()` when role permissions miss.
 
 ---
 

--- a/libraries/adapter/user/user.php
+++ b/libraries/adapter/user/user.php
@@ -301,7 +301,12 @@ class JUser extends JObject
 				return true;
 			}
 		}
-
+		// Fallback capability check in case none of the roles matched.
+		if ($this->has_cap($cap))
+		{
+			return true;
+		}
+		
 		return false;
 	}
 


### PR DESCRIPTION
## Summary
- ensure `JUser::authorise()` checks user capability after iterating roles
- document the new fallback check in adapter changelog

## Testing
- `php -l libraries/adapter/user/user.php`

------
https://chatgpt.com/codex/tasks/task_e_68421180fde4832aa25be67e97341ef3