### PR TITLE
Fix plugin update hook slug

### DIFF
--- a/vikrentcar.php
+++ b/vikrentcar.php
@@ -62,7 +62,8 @@ add_filter('auto_update_plugin', array('VikRentCarInstaller', 'useAutoUpdate'), 
  *
  * @since  1.2.0
  */
-add_action('in_plugin_update_message-vikrentcar/vikrentcar.php', array('VikRentCarInstaller', 'getUpdateMessage'), 10, 2);
+$plugin_slug = plugin_basename(__FILE__);
+add_action('in_plugin_update_message-' . $plugin_slug, array('VikRentCarInstaller', 'getUpdateMessage'), 10, 2);
 
 // init pagination layout
 VikRentCarBuilder::setupPaginationLayout();


### PR DESCRIPTION
## Summary
- compute plugin slug dynamically in `vikrentcar.php` so the update message hook adapts if the directory changes

## Testing
- `php -l vikrentcar.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684214e52634832a9445ff4dfc37ea9d